### PR TITLE
fixed the thing

### DIFF
--- a/src/controllers/question.js
+++ b/src/controllers/question.js
@@ -17,7 +17,7 @@ exports.getQuestion = function ({ user, params }, res, next) {
     const userPermissions = (user && user.permissions) || PERMISSIONS_ANON
 
     Promise.all([
-        questionModel.getQuestion(params.id),
+        questionModel.getQuestion(params.code, params.id),
         likesModel.getLikes({ type: TABLE_NAMES.QUESTIONS, id: params.id }),
         likesModel.getUserLiked({ type: TABLE_NAMES.QUESTIONS, id: params.id, userID })
     ])

--- a/src/controllers/review.js
+++ b/src/controllers/review.js
@@ -17,7 +17,7 @@ exports.getReview = function ({ user, params }, res, next) {
     const userPermissions = (user && user.permissions) || PERMISSIONS_ANON
 
     Promise.all([
-        reviewModel.getReview(params.id),
+        reviewModel.getReview(params.code, params.id),
         likesModel.getLikes({ type: TABLE_NAMES.REVIEWS, id: params.id }),
         likesModel.getUserLiked({ type: TABLE_NAMES.REVIEWS, id: params.id, userID })
     ])

--- a/src/models/question.js
+++ b/src/models/question.js
@@ -14,15 +14,19 @@ class Question {
 
     /**
      * Gets specific question corresponding to an id.
-     * @param   {id}      questionID Required id param.
-     * @returns {object}             Single question
+     * @param   {string}    code    course code.
+     * @param   {number}    id      id of the question.
+     * @throws  {APIError}
+     * @returns {object}            single question
      */
-    getQuestion(id) {
+    getQuestion(code, id) {
         return this.db
-            .run(`SELECT * FROM ${QUESTIONS} WHERE id=@id`,
-                {
-                    [QUESTIONS]: { id }
-                })
+            .run(`SELECT * FROM ${QUESTIONS} q
+            WHERE q.id=@id AND q.courseID=(SELECT c.id FROM ${COURSES} c WHERE c.code=@code)`,
+            {
+                [QUESTIONS]: { id },
+                [COURSES]: { code }
+            })
             .then(([row]) => {
                 if (row) return row
                 throw new APIError(ERRORS.QUESTION.MISSING)

--- a/src/models/review.js
+++ b/src/models/review.js
@@ -24,16 +24,19 @@ class Review {
 
     /**
      * Gets specific review corresponding to an id.
-     * @param   {number}  id   Required id param.
+     * @param   {string}    code    course code.
+     * @param   {number}    id      id of the review.
      * @throws  {APIError}
-     * @returns {object}
+     * @returns {object}            single review
      */
-    getReview(id) {
+    getReview(code, id) {
         return this.db
-            .run(`SELECT * FROM ${REVIEWS} WHERE id=@id`,
-                {
-                    [REVIEWS]: { id }
-                })
+            .run(`SELECT * FROM ${REVIEWS} r
+            WHERE r.id=@id AND r.courseID=(SELECT c.id FROM ${COURSES} c WHERE c.code=@code)`,
+            {
+                [REVIEWS]: { id },
+                [COURSES]: { code }
+            })
             .then(([row]) => {
                 if (row) return row
                 throw new APIError(ERRORS.REVIEW.MISSING)

--- a/tests/routes/questions.js
+++ b/tests/routes/questions.js
@@ -2,6 +2,7 @@ const app = require('../../src')
 const assert = require('assert')
 const supertest = require('supertest')(app)
 const { expect } = require('chai')
+const { ERRORS } = require('../../src/error/constants')
 
 describe('Test question routes', () => {
     describe('GET /api/course/ACCT1501/question/1', () => {
@@ -29,6 +30,24 @@ describe('Test question routes', () => {
         it('question has a course code', () =>
             request.then(({ body }) =>
                 expect(body.courseID).is.a('number'))
+        )
+    })
+
+    describe('GET /api/course/ACCT1501/question/10 (error)', () => {
+        let request
+
+        before(() => {
+            request = supertest
+                .get('/api/course/ACCT1501/question/10')
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect(404)
+            return request
+        })
+
+        it('has correct error code', () =>
+            request.then(({ body }) =>
+                expect(body.code).to.equal(ERRORS.QUESTION.MISSING.code))
         )
     })
 

--- a/tests/routes/review.js
+++ b/tests/routes/review.js
@@ -2,6 +2,7 @@ const app = require('../../src')
 const supertest = require('supertest')(app)
 const assert = require('assert')
 const { expect } = require('chai')
+const { ERRORS } = require('../../src/error/constants')
 
 describe('Test review routes', function () {
     describe('GET /api/course/ACCT1511/review', () => {
@@ -47,6 +48,24 @@ describe('Test review routes', function () {
         it('review has a course code', () =>
             getRequest.then(({ body }) =>
                 expect(body.courseID).to.be.a('number'))
+        )
+    })
+
+    describe('GET /api/course/ACCT1501/review/10 (error)', () => {
+        let request
+
+        before(() => {
+            request = supertest
+                .get('/api/course/ACCT1501/review/10')
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect(404)
+            return request
+        })
+
+        it('has correct error code', () =>
+            request.then(({ body }) =>
+                expect(body.code).to.equal(ERRORS.REVIEW.MISSING.code))
         )
     })
 


### PR DESCRIPTION
Fixes bug where the course code in the getReview and getQuestion endpoints doesn't do anything (now returns 404 error if the course code doesn't correspond to the review/question)

Note that this bug still exists on comment endpoints, but it's a little more complex to fix there and can't been seen in the frontend anyway.