### PR TITLE
Dismiss reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,9 @@ RUN echo yes | apt-get install -y msodbcsql
 RUN echo yes | apt-get install -y mssql-tools 
 RUN locale-gen en_US en_US.UTF-8 
 RUN dpkg-reconfigure -f noninteractive locales
+
+ENV PATH="/opt/mssql-tools/bin:${PATH}"
+ENV ACCEPT_EULA="Y"
+ARG SA_PASSWORD
+
+EXPOSE 1433

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+services:
+  smartcourse-testing:
+    container_name: 'smartcourse-testing'
+    build:
+      context: .
+    ports:
+      - "1433:1433"
+    environment:
+      SA_PASSWORD: ${LOCAL_SQL_PASSWORD}
+      ACCEPT_EULA: "Y"
+    healthcheck:
+      test: sqlcmd -S localhost,1433 -U SA -P "$SA_PASSWORD" -Q 'select * from smartcourse-testing.testdb.tables'
+

--- a/docker.sh
+++ b/docker.sh
@@ -5,20 +5,15 @@ DOCKER_NAME='smartcourse-testing'
 docker kill $DOCKER_NAME
 docker rm $DOCKER_NAME
 
+# bail out if any errors
 set -ex
 
-# docker build --tag $DOCKER_NAME .
-docker run \
-    --name $DOCKER_NAME \
-    --env 'ACCEPT_EULA=Y' \
-    --env "SA_PASSWORD=$LOCAL_SQL_PASSWORD" \
-    -p 1433:1433 \
-    -d microsoft/mssql-server-linux:2017-latest
+# start the container using compose config
+SA_PASSWORD="$LOCAL_SQL_PASSWORD" docker-compose up -d
 
-sleep 10
-
-docker exec -it $DOCKER_NAME /opt/mssql-tools/bin/sqlcmd \
-   -S localhost,1433 -U SA -P "$LOCAL_SQL_PASSWORD" \
+# initdb
+docker exec -it $DOCKER_NAME sqlcmd \
+   -S localhost,1433 \
+   -U SA \
+   -P "$LOCAL_SQL_PASSWORD" \
    -Q 'CREATE DATABASE testdb'
-
-# really this should be a dockerfile as with all db config \_(* *)_/

--- a/src/controllers/report.js
+++ b/src/controllers/report.js
@@ -60,3 +60,13 @@ exports.getReportSummary = function ({ user, query }, res, next) {
         .then(getResponseHandler(res))
         .catch(next)
 }
+
+exports.dismissReport = function ({ user, params }, res, next) {
+    if (user.permissions < PERMISSIONS_MOD) {
+        throw new APIError(ERRORS.MISC.AUTHORIZATION)
+    }
+
+    reportModel.dismissReport(params.id)
+        .then(getResponseHandler(res))
+        .catch(next)
+}

--- a/src/models/db/index.js
+++ b/src/models/db/index.js
@@ -13,7 +13,7 @@ class DB extends EventEmitter {
         super()
 
         console.log('Connecting to database')
-        
+
         this.connections = []
         this.ready = false
 

--- a/src/models/report.js
+++ b/src/models/report.js
@@ -43,6 +43,20 @@ class Report {
     }
 
     /**
+     * Report Id
+     * @param {string} reportId
+     */
+    dismissReport(reportId) {
+        return this.db
+            .run(
+                `DELETE ${REPORTS} WHERE id=@id;`,
+                {
+                    [REPORTS]: { id: reportId }
+                }
+            )
+    }
+
+    /**
      * Get all of dem reports for a given post
      * @param   {object} queryObject
      * @returns {Array}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,8 +13,8 @@ api.use('/course', courseRouter)
 api.use('/subject', subjectRouter)
 
 /* Root API for debugging */
-api.get('/', function (req, res) {
-    res.send('<h1>Welcome to the API</h1>')
+api.get('/', function (_, res) {
+    res.sendStatus(200)
 })
 
 api.use('*', function (_, res) {

--- a/src/routes/uni.js
+++ b/src/routes/uni.js
@@ -23,4 +23,7 @@ uni.get('/sessions', uniController.getSessions)
 /* Return all posts with reports, sorted by number of reports */
 uni.get('/reports', isModOrHigher, reportController.getReportSummary)
 
+/* Delete the relevant report */
+uni.delete('/report/:id', isModOrHigher, reportController.dismissReport)
+
 module.exports = uni

--- a/tests/routes/uni.js
+++ b/tests/routes/uni.js
@@ -30,7 +30,7 @@ describe('Uni route testing', function () {
             })
     )
 
-    describe('GET uni/reports', () => {
+    describe.only('GET uni/reports', () => {
         let request1, request2, request3
         const report = { reason: 'It suuucks' }
         let getRequest
@@ -56,16 +56,15 @@ describe('Uni route testing', function () {
                 .set('Authorization', `Bearer ${global.idToken1}`)
                 .expect(201)
             // get the reports
-            return Promise.all([request1, request2, request3])
-                .then(() => {
-                    getRequest = supertest
-                        .get('/api/uni/reports')
-                        .set('Accept', 'application/json')
-                        .set('Authorization', `Bearer ${global.idTokenSuper}`)
-                        .expect('Content-Type', /json/)
-                        .expect(200)
-                    return getRequest
-                })
+            getRequest = Promise.all([request1, request2, request3])
+                .then(() => supertest
+                    .get('/api/uni/reports')
+                    .set('Accept', 'application/json')
+                    .set('Authorization', `Bearer ${global.idTokenSuper}`)
+                    .expect('Content-Type', /json/)
+                    .expect(200)
+                )
+            return getRequest
         })
 
         it('has 3 entries', () =>
@@ -81,6 +80,36 @@ describe('Uni route testing', function () {
             })
         )
         // NOTE we don't check the number of reports because of the async report test for questions
+
+        describe('DELETE a report', () => {
+            let deleteRequest
+
+            before('delete a report', () => {
+                deleteRequest = getRequest.then(() =>
+                    supertest
+                        .delete('/api/uni/report/1')
+                        .set('Accept', 'application/json')
+                        .set('Authorization', `Bearer ${global.idTokenSuper}`)
+                        .expect(200)
+                )
+
+                return deleteRequest
+            })
+
+            it('deletes', () =>
+                deleteRequest.then(
+                    () => supertest
+                        .get('/api/uni/reports')
+                        .set('Accept', 'application/json')
+                        .set('Authorization', `Bearer ${global.idTokenSuper}`)
+                        .expect('Content-Type', /json/)
+                        .expect(200)
+                        .then(({ body }) => {
+                            expect(body.length).to.equal(2)
+                        })
+                )
+            )
+        })
     })
 
     describe('GET uni/reports (error)', () => {

--- a/tests/routes/uni.js
+++ b/tests/routes/uni.js
@@ -9,6 +9,7 @@ describe('Uni route testing', function () {
             .set('Accept', 'application/json')
             .expect('Content-Type', /json/)
             .expect(200)
+            .then(_ => _)
     )
 
     it('GET uni/faculties', () =>
@@ -17,6 +18,7 @@ describe('Uni route testing', function () {
             .set('Accept', 'application/json')
             .expect('Content-Type', /json/)
             .expect(200)
+            .then(_ => _)
     )
 
     it('GET uni/sessions', () =>
@@ -30,7 +32,7 @@ describe('Uni route testing', function () {
             })
     )
 
-    describe.only('GET uni/reports', () => {
+    describe('GET uni/reports', () => {
         let request1, request2, request3
         const report = { reason: 'It suuucks' }
         let getRequest
@@ -43,18 +45,24 @@ describe('Uni route testing', function () {
                 .set('Authorization', `Bearer ${global.idToken0}`)
                 .send(report)
                 .expect(201)
+                .then(body => body)
+
             request2 = supertest
                 .post('/api/course/ACCT1501/question/1/report')
                 .send(report)
                 .set('Accept', 'application/json')
                 .set('Authorization', `Bearer ${global.idToken1}`)
                 .expect(201)
+                .then(body => body)
+
             request3 = supertest
                 .post('/api/course/ACCT1501/question/2/report')
                 .send(report)
                 .set('Accept', 'application/json')
                 .set('Authorization', `Bearer ${global.idToken1}`)
                 .expect(201)
+                .then(body => body)
+
             // get the reports
             getRequest = Promise.all([request1, request2, request3])
                 .then(() => supertest
@@ -63,6 +71,7 @@ describe('Uni route testing', function () {
                     .set('Authorization', `Bearer ${global.idTokenSuper}`)
                     .expect('Content-Type', /json/)
                     .expect(200)
+                    .then(body => body)
                 )
             return getRequest
         })
@@ -91,6 +100,7 @@ describe('Uni route testing', function () {
                         .set('Accept', 'application/json')
                         .set('Authorization', `Bearer ${global.idTokenSuper}`)
                         .expect(200)
+                        .then(res => res)
                 )
 
                 return deleteRequest
@@ -122,6 +132,8 @@ describe('Uni route testing', function () {
                 .set('Authorization', `Bearer ${global.idToken0}`)
                 .expect('Content-Type', /json/)
                 .expect(403)
+                .then(data => data)
+
             return getRequest
         })
 
@@ -141,6 +153,8 @@ describe('Uni route testing', function () {
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
                 .expect(200)
+                .then(data => data)
+
             return getRequest
         })
 


### PR DESCRIPTION
Reports can now be dismissed via the API call `DELETE /uni/report/<id>`